### PR TITLE
Add optional LangChain dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # green-hill-app
 
+This repository contains the Green Hill Club application.
+
+## Optional dependencies
+
+The core app does not require additional libraries.  Utilities for working with the
+vector store (see `document_store.py` and `precompute_vector_store.py`) rely on the
+LangChain ecosystem and other helpers.  To enable these features, install the
+optional packages listed in [`requirements.txt`](requirements.txt):
+
+```
+pip install -r requirements.txt
+```
+
+These dependencies include `langchain-openai`, `langchain-chroma`, `langchain-text-splitters`, `pypdf`, `tqdm`, and `docx2txt`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+langchain
+langchain-openai
+langchain-chroma
+langchain-text-splitters
+pypdf
+tqdm
+docx2txt


### PR DESCRIPTION
## Summary
- add `requirements.txt` with optional LangChain and document processing packages
- document optional dependencies and usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ghc_complete')*

------
https://chatgpt.com/codex/tasks/task_e_68a07d0224b883209fc24f047f90f05b